### PR TITLE
Updates Eclipse to 2023-12 R + updates missed Maven test stage to 3.9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,6 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5
         with:
-          maven-version: 3.9.5
+          maven-version: 3.9.6
       - name: Test with Maven
         run: mvn --batch-mode --update-snapshots clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
 
   <repositories>
     <repository>
-      <id>eclipse-2023-09</id>
+      <id>eclipse-2023-12</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/releases/2023-09</url>
+      <url>https://download.eclipse.org/releases/2023-12</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Closes #23.