### PR TITLE
Updates GitHub Action setup-maven to v5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.14
       - name: Build with Maven
@@ -36,7 +36,7 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.14
       - name: Create JavaDoc with Maven
@@ -58,7 +58,7 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.14
       - name: Test with Maven


### PR DESCRIPTION
This should fix the Node.js v20 warning.